### PR TITLE
refactor: Comment out subscription cancellation form in AccountInfo c…

### DIFF
--- a/app/(chat)/account/components/account-info.tsx
+++ b/app/(chat)/account/components/account-info.tsx
@@ -364,7 +364,7 @@ export default function AccountInfo({
                         </Button>
                       </Link>
 
-                      <Form action={cancelSubscriptionAction}>
+                      {/* <Form action={cancelSubscriptionAction}>
                         <input
                           type="hidden"
                           name="subscriptionId"
@@ -373,7 +373,7 @@ export default function AccountInfo({
                         <Button className="px-4 py-2 text-sm w-full font-medium bg-rose-500 hover:bg-rose-600 text-white">
                           <X className="h-4 w-4 mr-2" /> Cancelar assinatura
                         </Button>
-                      </Form>
+                      </Form> */}
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
This pull request includes a small change to the `app/(chat)/account/components/account-info.tsx` file. The change comments out the `Form` element that was responsible for handling the cancellation of a subscription.

Changes to `app/(chat)/account/components/account-info.tsx`:

* Commented out the `Form` element that includes the `cancelSubscriptionAction` action and related input elements. [[1]](diffhunk://#diff-7ce9a33e81bc0bad0b5b7da7e5d42ea3cf1ba2b3f52bbc29cccfcd0ae131d6a3L367-R367) [[2]](diffhunk://#diff-7ce9a33e81bc0bad0b5b7da7e5d42ea3cf1ba2b3f52bbc29cccfcd0ae131d6a3L376-R376)